### PR TITLE
When parsing incoming JSON into clojure form that will undergo schema…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/lambdaconnect-model "1.0.11"
+(defproject io.spinney/lambdaconnect-model "1.0.12"
   :description "Model parsing and scoping"
   :url "https://github.com/spinneyio/lambdaconnect-model"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/lambdaconnect_model/tools.clj
+++ b/src/lambdaconnect_model/tools.clj
@@ -88,7 +88,7 @@
 
 (defn parser-for-relationship [rel]
   (if (:to-many rel)
-    #(do (assert (or (nil? %) (sequential? %)) (str "The to-many relationship requires a sequence as its argument: " %)))       
+    #(do (assert (or (nil? %) (sequential? %)) (str "The to-many relationship requires a sequence as its argument: " %))       
          (map (fn [uuid-string] {:app/uuid (string->uuid uuid-string)}) %))
     #(when % {:app/uuid (string->uuid %)})))
 

--- a/src/lambdaconnect_model/tools.clj
+++ b/src/lambdaconnect_model/tools.clj
@@ -88,7 +88,8 @@
 
 (defn parser-for-relationship [rel]
   (if (:to-many rel)
-    #(map (fn [uuid-string] {:app/uuid (string->uuid uuid-string)}) %)
+    #(do (assert (or (nil? %) (sequential? %)) (str "The to-many relationship requires a sequence as its argument: " %)))       
+         (map (fn [uuid-string] {:app/uuid (string->uuid uuid-string)}) %))
     #(when % {:app/uuid (string->uuid %)})))
 
 (defn inverse-parser-for-relationship [rel]


### PR DESCRIPTION
… validation using clojure.spec, we can encounter errors. One of the errors occurs if a to-many relationship is being sent as a to-one. In this case, the parser tried to convert the string to a sequence and treat each letter as a potential UUID. This caused error messages to be really cryptic - let us add an assert that takes care of this problem.